### PR TITLE
Update pom with maven-compiler-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,8 +4,24 @@
   <artifactId>riak-data-migrator</artifactId>
   <packaging>jar</packaging>
   <name>Riak Data Migrator</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+  </properties>
+
   <build>
   	<plugins>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.1</version>
+            <configuration>
+                <source>1.6</source>
+                <target>1.6</target>
+                <compilerArgument>-Xlint:unchecked</compilerArgument>
+            </configuration>
+        </plugin>
   		<plugin>
   			<groupId>org.apache.maven.plugins</groupId>
   			<artifactId>maven-assembly-plugin</artifactId>


### PR DESCRIPTION
Some maven installations have the default `-source` set to
1.3 in the super pom. This adds the maven-compiler-plugin to the pom and sets `-source` and
`-target` to 1.6

Also added UTF-8 encoding specification to eliminate warnings.

Resolves #13
