### PR TITLE
Do not decode -b args.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <artifactId>riak-data-migrator</artifactId>
   <packaging>jar</packaging>
   <name>Riak Data Migrator</name>
-  <version>0.2.8</version>
+  <version>0.2.9</version>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/com/basho/proserv/datamigrator/Main.java
+++ b/src/main/java/com/basho/proserv/datamigrator/Main.java
@@ -255,7 +255,7 @@ public class Main {
 		
 		// Single bucket specifier
 		if (cmd.hasOption("b")) {
-			config.addBucketName(Utilities.urlDecode(cmd.getOptionValue("b")));
+			config.addBucketName(cmd.getOptionValue("b"));
 			config.setOperation(Configuration.Operation.BUCKETS);
 		}
 		// Bucket filename


### PR DESCRIPTION
We need to standardize on an input format.  This change suggests that we should not be doing any form of encoding or format change immediately after receiving input.

It is best to leave these decisions to components which need to directly interact with output and tie them to functions which carry out the intended output, rather than assume things early which may not be true later.

To put it another way, do not prematurely or permanently mutate use input.  There are likely other cases of this same thing happening elsewhere.  In the interest of time, we are only fixing this one for now.